### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To configure your project manually, follow these steps:
    "main": "lib/commonjs/index.js",
    "module": "lib/module/index.js",
    "react-native": "src/index.js",
-   "typescript": "lib/typescript/src/index.d.ts",
+   "types": "lib/typescript/src/index.d.ts",
    "files": [
      "lib/",
      "src/"


### PR DESCRIPTION
The automatic way adds a `types` field, not a `typescript` one.

So in the manual one it should probably also be `types`.