### PR TITLE
fixed `types` in package.json generated by `bob init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To configure your project manually, follow these steps:
    "main": "lib/commonjs/index.js",
    "module": "lib/module/index.js",
    "react-native": "src/index.js",
-   "types": "lib/typescript/src/index.d.ts",
+   "types": "lib/typescript/index.d.ts",
    "files": [
      "lib/",
      "src/"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -121,7 +121,7 @@ yargs
     }
 
     if (targets.includes('typescript')) {
-      entries.types = path.join(output, 'typescript', source, 'index.d.ts');
+      entries.types = path.join(output, 'typescript', 'index.d.ts');
     }
 
     const prepare = 'bob build';


### PR DESCRIPTION
If you perform `bob init`,  it's written `lib/typescript/src/index.d.ts` to `types` in package.json. 
However, it's a different path that actually outputs TypeScript type definitions.

When you perform `bob build`, it will be output to `lib/typescript/index.d.ts`.
