### PR TITLE
feat: add option to specify tsc path

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Example:
 
 Enable generating type definitions with `tsc` if your source code is written in [TypeScript](http://www.typescriptlang.org/).
 
-By default, it'll use the `tsconfig.json` file in your project root. If you want to use a different config, you can specify it using the `project` option. Furthermore, the tsc binary will be resolved to ./node_modules/.bin/tsc. Use the `tsc` option to sepcify a different path.
+By default, it'll use the `tsconfig.json` file in your project root. If you want to use a different config, you can specify it using the `project` option. Furthermore, the tsc binary will be resolved to ./node_modules/.bin/tsc. Use the `tsc` option to specify a different path.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Example:
 
 Enable generating type definitions with `tsc` if your source code is written in [TypeScript](http://www.typescriptlang.org/).
 
-By default, it'll use the `tsconfig.json` file in your project root. If you want to use a different config, you can specify it using the `project` option.
+By default, it'll use the `tsconfig.json` file in your project root. If you want to use a different config, you can specify it using the `project` option. Furthermore, the tsc binary will be resolved to ./node_modules/.bin/tsc. Use the `tsc` option to sepcify a different path.
 
 Example:
 

--- a/src/targets/typescript.ts
+++ b/src/targets/typescript.ts
@@ -78,10 +78,9 @@ export default async function build({
       );
     }
 
-    const tscPath = options?.tsc
-      ? options.tsc
-      : path.join(root, 'node_modules', '.bin', 'tsc');
-    let tsc = tscPath + (platform() === 'win32' ? '.cmd' : '');
+    let tsc = options?.tsc
+      ? path.resolve(root, options.tsc)
+      : path.join(root, 'node_module') + (platform() === 'win32' ? '.cmd' : '');
 
     if (!(await fs.pathExists(tsc))) {
       tsc = spawn

--- a/src/targets/typescript.ts
+++ b/src/targets/typescript.ts
@@ -80,7 +80,7 @@ export default async function build({
 
     let tsc = options?.tsc
       ? path.resolve(root, options.tsc)
-      : path.join(root, 'node_module') + (platform() === 'win32' ? '.cmd' : '');
+      : path.join(root, 'node_modules') + (platform() === 'win32' ? '.cmd' : '');
 
     if (!(await fs.pathExists(tsc))) {
       tsc = spawn

--- a/src/targets/typescript.ts
+++ b/src/targets/typescript.ts
@@ -93,7 +93,9 @@ export default async function build({
           'tsc'
         )}. Consider adding ${chalk.blue('typescript')} to your ${chalk.blue(
           'devDependencies'
-        )} instead.`
+        )} or specifying the ${chalk.blue(
+          'tsc'
+        )} option for the typescript target.`
       );
     }
 
@@ -127,7 +129,9 @@ export default async function build({
           'node_modules'
         )} or present in $PATH. Make sure you have added ${chalk.blue(
           'typescript'
-        )} to your ${chalk.blue('devDependencies')}.`
+        )} to your ${chalk.blue('devDependencies')} or specify the ${chalk.blue(
+          'tsc'
+        )} option for typescript.`
       );
     }
   } catch (e) {

--- a/src/targets/typescript.ts
+++ b/src/targets/typescript.ts
@@ -8,7 +8,7 @@ import { platform } from 'os';
 import { Input } from '../types';
 
 type Options = Input & {
-  options?: { project?: string };
+  options?: { project?: string; tsc?: string };
 };
 
 export default async function build({
@@ -78,9 +78,10 @@ export default async function build({
       );
     }
 
-    let tsc =
-      path.join(root, 'node_modules', '.bin', 'tsc') +
-      (platform() === 'win32' ? '.cmd' : '');
+    const tscPath = options?.tsc
+      ? options.tsc
+      : path.join(root, 'node_modules', '.bin', 'tsc');
+    let tsc = tscPath + (platform() === 'win32' ? '.cmd' : '');
 
     if (!(await fs.pathExists(tsc))) {
       tsc = spawn


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
For the typescript target, this PR aims to add an option to specify a path to tsc. We are using bob in a workspace setup. With this option, we can resolve tsc's path to the workspace root's node modules so that not the global tsc is being used. 

## Test Plan

I've tested this fork with our setup and it works.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [N/A ] I mentioned this change in `CHANGELOG.md`
- [ X] I updated the typed files (TS and Flow)
- [N/A ] I added a sample use of the API in the example project (`example/App.js`)
