### PR TITLE
Fix `types` path in template package.json

### DIFF
--- a/templates/library/$package.json
+++ b/templates/library/$package.json
@@ -4,7 +4,7 @@
   "description": "<%= project.description %>",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index.tsx",
   "files": [
     "src",


### PR DESCRIPTION
Building the `bob create` example places the transpiled contents of `src/` directly under the lib folders (`commonjs/`, `typescript/`, etc), i.e.:

`src/index.tsx` -> `lib/typescript/index.d.ts`

So the path to `types` in the default package.json, which includes `src/`, results in TS not being able to find types when the built library is consumed.