### PR TITLE
fix: fix Obj-C file extension in project.pbxproj

### DIFF
--- a/templates/native-library/ios/{%= project.name %}.xcodeproj/project.pbxproj
+++ b/templates/native-library/ios/{%= project.name %}.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 <% if (project.swift) { %>
 		F4FF95D7245B92E800C19C63 /*  <%= project.name %>.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /*  <%= project.name %>.swift */; };
 <% } %>
-		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */; };
+		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -40,7 +40,7 @@
 		F4FF95D6245B92E800C19C63 /* <%= project.name %>.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = <%= project.name %>.swift; sourceTree = "<group>"; };
 <% } else { %>
 		B3E7B5881CC2AC0600A0062D /* <%= project.name %>.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = <%= project.name %>.h; sourceTree = "<group>"; };
-		B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = <%= project.name %>.mm; sourceTree = "<group>"; };
+		B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = <%= project.name %>.m; sourceTree = "<group>"; };
 <% } %>
 /* End PBXFileReference section */
 
@@ -76,7 +76,7 @@
 				F4FF95D5245B92E700C19C63 /* <%= project.name %>-Bridging-Header.h */,
 <% } else { %>
 				B3E7B5881CC2AC0600A0062D /* <%= project.name %>.h */,
-				B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */,
+				B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */,
 <% } %>
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
@@ -146,7 +146,7 @@
 				F4FF95D7245B92E800C19C63 /* <%= project.name %>.swift in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* <%= project.name %>.m in Sources */,
 <% } else { %>
-				5E555C0D2413F4C50049A1A2 /* <%= project.name %>.mm in Sources */,
+				5E555C0D2413F4C50049A1A2 /* <%= project.name %>.m in Sources */,
 <% } %>
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/templates/native-library/ios/{%= project.name %}.xcodeproj/project.pbxproj
+++ b/templates/native-library/ios/{%= project.name %}.xcodeproj/project.pbxproj
@@ -9,11 +9,13 @@
 /* Begin PBXBuildFile section */
 <% if (project.cpp) { %>
 		5E46D8CD2428F78900513E24 /* example.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E46D8CB2428F78900513E24 /* example.cpp */; };
-<% } %>
-<% if (project.swift) { %>
-		F4FF95D7245B92E800C19C63 /*  <%= project.name %>.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /*  <%= project.name %>.swift */; };
-<% } %>
+		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */; };
+<% else if (project.swift) { %>
 		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */; };
+		F4FF95D7245B92E800C19C63 /*  <%= project.name %>.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /*  <%= project.name %>.swift */; };
+<% } else { %>
+		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */; };
+<% } %>
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,14 +35,14 @@
 <% if (project.cpp) { %>
 		5E46D8CB2428F78900513E24 /* example.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = example.cpp; path = ../cpp/example.cpp; sourceTree = "<group>"; };
 		5E46D8CC2428F78900513E24 /* example.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = example.h; path = ../cpp/example.h; sourceTree = "<group>"; };
-<% } %>
-<% if (project.swift) { %>
+		B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = <%= project.name %>.mm; sourceTree = "<group>"; };
+<% } else if (project.swift) { %>
 		B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = <%= project.name %>.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* <%= project.name %>-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "<%= project.name %>-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* <%= project.name %>.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = <%= project.name %>.swift; sourceTree = "<group>"; };
 <% } else { %>
 		B3E7B5881CC2AC0600A0062D /* <%= project.name %>.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = <%= project.name %>.h; sourceTree = "<group>"; };
-		B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = <%= project.name %>.m; sourceTree = "<group>"; };
+		B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = <%= project.name %>.m; sourceTree = "<group>"; };
 <% } %>
 /* End PBXFileReference section */
 
@@ -69,12 +71,12 @@
 <% if (project.cpp) { %>
 				5E46D8CB2428F78900513E24 /* example.cpp */,
 				5E46D8CC2428F78900513E24 /* example.h */,
-<% } %>
-<% if (project.swift) { %>
+				B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */,
+<% } else if (project.swift) { %>
 				F4FF95D6245B92E800C19C63 /* <%= project.name %>.swift */,
 				B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */,
 				F4FF95D5245B92E700C19C63 /* <%= project.name %>-Bridging-Header.h */,
-<% } else { %>
+<% } else { %>
 				B3E7B5881CC2AC0600A0062D /* <%= project.name %>.h */,
 				B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */,
 <% } %>
@@ -141,12 +143,12 @@
 			files = (
 <% if (project.cpp) { %>
 				5E46D8CD2428F78900513E24 /* example.cpp in Sources */,
-<% } %>
-<% if (project.swift) { %>
+				5E555C0D2413F4C50049A1A2 /* <%= project.name %>.mm in Sources */,
+<% } else if (project.swift) { %>
 				F4FF95D7245B92E800C19C63 /* <%= project.name %>.swift in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* <%= project.name %>.m in Sources */,
 <% } else { %>
-				5E555C0D2413F4C50049A1A2 /* <%= project.name %>.m in Sources */,
+				B3E7B58A1CC2AC0600A0062D /* <%= project.name %>.m in Sources */,
 <% } %>
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/templates/native-library/ios/{%= project.name %}.xcodeproj/project.pbxproj
+++ b/templates/native-library/ios/{%= project.name %}.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 <% if (project.cpp) { %>
 		5E46D8CD2428F78900513E24 /* example.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E46D8CB2428F78900513E24 /* example.cpp */; };
 		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.mm */; };
-<% else if (project.swift) { %>
+<% } else if (project.swift) { %>
 		5E555C0D2413F4C50049A1A2 /* <%= project.name %>.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* <%= project.name %>.m */; };
 		F4FF95D7245B92E800C19C63 /*  <%= project.name %>.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /*  <%= project.name %>.swift */; };
 <% } else { %>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Currently when creating Native Module package for iOS the invalid Objective-C implementation file extension (`.mm`) is provided in `project.pbxproj`. This causes the inability to open and edit the package [`.m` file](https://github.com/react-native-community/bob/tree/master/templates/objc-library/ios) in XCode.

This PR fixes that issue simply by replacing the incorrect file extension with the correct one.

## Test Plan

After generating the project with the change I can open implementation code in the XCode.

### What's required for testing (prerequisites)?

XCode!

### What are the steps to reproduce (after prerequisites)?

Generate iOS Native Project and try to open main file in XCode.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
